### PR TITLE
Update filter removal to match latest Post Kinds

### DIFF
--- a/integrations/post-kinds.php
+++ b/integrations/post-kinds.php
@@ -18,7 +18,8 @@ function autonomie_post_kinds_init() {
 		add_filter( 'kind_icon_display', '__return_false', 10 );
 	}
 
-	remove_filter( 'the_content', array( 'Kind_View', 'content_response' ), 20 );
+	remove_filter( 'the_content', array( 'Kind_View', 'content_response' ), 9 );
+	remove_filter( 'the_excerpt', array( 'Kind_View', 'excerpt_response' ), 9 );
 	remove_action( 'wp_enqueue_scripts', array( 'Post_Kinds_Plugin', 'style_load' ) );
 }
 add_action( 'init', 'autonomie_post_kinds_init' );


### PR DESCRIPTION
The latest version of Post Kinds (v3.2.6) changed the priority the filters are applied to content, from 20 to 9. This resulted in remove_filter no longer working as intended. Changing the priority to 9 fixes the problem.